### PR TITLE
Improve modularity

### DIFF
--- a/unet/conv.py
+++ b/unet/conv.py
@@ -19,6 +19,7 @@ class ConvolutionalBlock(nn.Module):
             dropout: float = 0,
             ):
         super().__init__()
+        self.out_channels = out_channels
 
         block = nn.ModuleList()
 
@@ -59,17 +60,11 @@ class ConvolutionalBlock(nn.Module):
             self.add_if_not_none(block, norm_layer)
             self.add_if_not_none(block, activation_layer)
 
-        dropout_layer = None
         if dropout:
             class_name = 'Dropout{}d'.format(dimensions)
             dropout_class = getattr(nn, class_name)
             dropout_layer = dropout_class(p=dropout)
             self.add_if_not_none(block, dropout_layer)
-
-        self.conv_layer = conv_layer
-        self.norm_layer = norm_layer
-        self.activation_layer = activation_layer
-        self.dropout_layer = dropout_layer
 
         self.block = nn.Sequential(*block)
 


### PR DESCRIPTION
Improve modularity by enabling to choose the number of convolutions and their number of channels in each block. To do so, one can give a list of lists to the model where each inner list corresponds to the `out_channels` of the different convolutions of a block and each outer list represents a block.

Example (the chosen numbers are purely arbitrary):
```python
from unet import UNet3D
model = UNet3D(3, 3, num_encoding_blocks=5, padding=1, encoder_out_channel_lists=[
    [8, 12], [16], [32, 7, 43], [64], [128, 64, 128]
    ], decoder_out_channel_lists=[
    [17], [23], [33, 42], [10]
])
```
Remark: the bottom block of the UNet is considered to be the last block of the encoder so there should be one block less in the decoder than the encoder.