### PR TITLE
Add base model to ease saving and loading models

### DIFF
--- a/unet/base_net.py
+++ b/unet/base_net.py
@@ -1,0 +1,50 @@
+import tarfile
+import tempfile
+import json
+import shutil
+
+import torch
+import torch.nn as nn
+
+
+class BaseNet(nn.Module, object):
+
+    def __init__(self, **kwargs):
+        super(BaseNet, self).__init__()
+
+        # Keep all the __init__parameters for saving/loading
+        self.net_parameters = kwargs
+
+    def save(self, filename):
+        with tarfile.open(filename, "w") as tar:
+            temporary_directory = tempfile.mkdtemp()
+            name = "{}/net_params.json".format(temporary_directory)
+            json.dump(self.net_parameters, open(name, "w"))
+            tar.add(name, arcname="net_params.json")
+            name = "{}/state.torch".format(temporary_directory)
+            torch.save(self.state_dict(), name)
+            tar.add(name, arcname="state.torch")
+            shutil.rmtree(temporary_directory)
+        return filename
+
+    @classmethod
+    def load(cls, filename, device=torch.device('cpu')):
+        with tarfile.open(filename, "r") as tar:
+            net_parameters = json.loads(
+                tar.extractfile("net_params.json").read().decode("utf-8"))
+            path = tempfile.mkdtemp()
+            tar.extract("state.torch", path=path)
+            net = cls(**net_parameters)
+            net.load_state_dict(
+                torch.load(
+                    path + "/state.torch",
+                    map_location=device,
+                )
+            )
+        return net, net_parameters
+
+
+def clean_locals(**kwargs):
+    del kwargs['self']
+    del kwargs['__class__']
+    return kwargs

--- a/unet/unet.py
+++ b/unet/unet.py
@@ -7,11 +7,12 @@ import torch.nn as nn
 from .encoding import Encoder, EncodingBlock
 from .decoding import Decoder
 from .conv import ConvolutionalBlock
+from .base_net import BaseNet, clean_locals
 
 __all__ = ['UNet', 'UNet2D', 'UNet3D']
 
 
-class UNet(nn.Module):
+class UNet(BaseNet):
     def __init__(
             self,
             in_channels: int = 1,
@@ -33,7 +34,7 @@ class UNet(nn.Module):
             dropout: float = 0,
             monte_carlo_dropout: float = 0,
             ):
-        super().__init__()
+        super().__init__(**clean_locals(**locals()))
 
         if encoder_out_channel_lists is None:
             encoder_out_channel_lists = []


### PR DESCRIPTION
Add a BaseNet class with load and save methods. Implementation taken from [harmonisation](https://github.com/TheoMoutakanni/harmonisation). 

Make UNet inherit from BaseNet and forward its arguments using `locals()` magic. It might not be the best way to do it but it seems to be the simplest to avoid rewriting all the arguments.